### PR TITLE
Add support for the Shure ANX4 receiver

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -5,9 +5,26 @@ This module will connect to the Shure receivers below to provide feedback status
 - Shure ULX-D (ULXD4, ULXD4D, ULXD4Q)
 - Shure QLX-D (QLXD4)
 - Shure SLX-D (SLXD4, SLXD4D)
-- Shure Axient Digital (AD4D, AD4Q, ANX4)
+- Shure Axient Digital (AD4D, AD4Q)
+- Shure Scalable Wireless (ANX4)
 
-Because the ANX4's channel count depends on the licenses installed on the receiver, selecting it exposes a "Licensed Channels" option in the instance configuration. Set this to the number of channels the receiver is licensed for (1-24, or up to 16 in ULX-D transmission mode) and the channels, slots, and variables will be created to match.
+#### ANX4
+
+The ANX4 is a scalable receiver that operates with either Axient Digital or ULX-D transmitters, rather than belonging to either system, so selecting it exposes two extra options in the instance configuration:
+
+| Option                | Description                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Transmission Mode** | The wireless system the receiver is operating in. Set this to match the mode selected on the receiver (Device RF > Transmission Mode).                  |
+| **Licensed Channels** | The number of channels the receiver is licensed for. The ANX4 does not ship with active channels, and licenses are activated per channel in ShureCloud. |
+
+The feature set follows the transmission mode, per the ANX4 user guide:
+
+| Transmission Mode  | Maximum Channels | Transmitter Slots |
+| ------------------ | ---------------- | ----------------- |
+| **Axient Digital** | 16               | 8 per channel     |
+| **ULX-D**          | 24               | Not supported     |
+
+Channels, slots, and variables are created to match. Standard and high density are reported by the receiver itself and do not need to be configured here.
 
 ### Available actions
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -5,7 +5,9 @@ This module will connect to the Shure receivers below to provide feedback status
 - Shure ULX-D (ULXD4, ULXD4D, ULXD4Q)
 - Shure QLX-D (QLXD4)
 - Shure SLX-D (SLXD4, SLXD4D)
-- Shure Axient Digital (AD4D, AD4Q)
+- Shure Axient Digital (AD4D, AD4Q, ANX4)
+
+Because the ANX4's channel count depends on the licenses installed on the receiver, selecting it exposes a "Licensed Channels" option in the instance configuration. Set this to the number of channels the receiver is licensed for (1-24, or up to 16 in ULX-D transmission mode) and the channels, slots, and variables will be created to match.
 
 ### Available actions
 

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -25,6 +25,6 @@
 		"entrypoint": "../src/index.js"
 	},
 	"manufacturer": "Shure",
-	"products": ["ULX-D", "QLX-D", "SLX-D", "Axient Digital (AD)"],
+	"products": ["ULX-D", "QLX-D", "SLX-D", "Axient Digital (AD, ANX4)"],
 	"keywords": ["Wireless Microphone"]
 }

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -25,6 +25,6 @@
 		"entrypoint": "../src/index.js"
 	},
 	"manufacturer": "Shure",
-	"products": ["ULX-D", "QLX-D", "SLX-D", "Axient Digital (AD, ANX4)"],
+	"products": ["ULX-D", "QLX-D", "SLX-D", "Axient Digital (AD)", "Scalable Wireless (ANX4)"],
 	"keywords": ["Wireless Microphone"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shure-wireless",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -105,7 +105,7 @@ export function updateActions() {
 		}
 	}
 
-	if (this.model.family == 'ad') {
+	if (this.model.slots > 0) {
 		actions['slot_rf_output'] = {
 			name: 'Set slot RF output (ADX)',
 			options: [this.SLOTS_A_FIELD, Fields.RfOutput],

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -286,7 +286,7 @@ export function updateFeedbacks() {
 		},
 	}
 
-	if (this.model.family == 'ad') {
+	if (this.model.slots > 0) {
 		feedbacks['slot_is_active'] = {
 			type: 'boolean',
 			name: 'Slot is Active',

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,10 @@ class ShureWirelessInstance extends InstanceBase {
 			resetConnection = true
 		}
 
+		if (this.config.channelCount != config.channelCount) {
+			resetConnection = true
+		}
+
 		if (this.config.meteringOn !== config.meteringOn) {
 			if (config.meteringOn === true) {
 				cmd = `< SET 0 METER_RATE ${this.config.meteringInterval} >`
@@ -63,11 +67,7 @@ class ShureWirelessInstance extends InstanceBase {
 
 		this.config = config
 
-		if (Models[this.config.modelID] !== undefined) {
-			this.model = Models[this.config.modelID]
-		} else {
-			this.log('debug', `Shure Model: ${this.config.modelID} NOT FOUND`)
-		}
+		this.setupModel()
 
 		this.updateActions()
 		this.updateFeedbacks()
@@ -169,6 +169,18 @@ class ShureWirelessInstance extends InstanceBase {
 				default: 'ulxd4',
 			},
 			{
+				type: 'number',
+				id: 'channelCount',
+				label: 'Licensed Channels',
+				tooltip: 'The number of channels licensed on the receiver.',
+				width: 2,
+				min: 1,
+				max: 24,
+				default: 4,
+				required: true,
+				isVisible: (config) => config.modelID === 'anx4',
+			},
+			{
 				type: 'checkbox',
 				id: 'meteringOn',
 				label: 'Enable Metering?',
@@ -224,12 +236,11 @@ class ShureWirelessInstance extends InstanceBase {
 		this.CHOICES_SLOTS = []
 		this.CHOICES_SLOTS_A = []
 
-		if (this.config.modelID !== undefined) {
-			this.model = Models[this.config.modelID]
-		} else {
+		if (this.config.modelID === undefined) {
 			this.config.modelID = 'ulxd4'
-			this.model = Models['ulxd4']
 		}
+
+		this.setupModel()
 
 		if (this.config.variableFormat === undefined) {
 			this.config.variableFormat = 'units'
@@ -454,6 +465,35 @@ class ShureWirelessInstance extends InstanceBase {
 		this.CHANNELS_A_FIELD.choices = this.CHOICES_CHANNELS_A
 		this.SLOTS_FIELD.choices = this.CHOICES_SLOTS
 		this.SLOTS_A_FIELD.choices = this.CHOICES_SLOTS_A
+	}
+
+	/**
+	 * INTERNAL: use the configuration to select the active model.  Models that declare
+	 * a maxChannels have a licensable channel count, which is taken from the config.
+	 *
+	 * @access protected
+	 * @since 2.4.0
+	 */
+	setupModel() {
+		let model = Models[this.config.modelID]
+
+		if (model === undefined) {
+			this.log('debug', `Shure Model: ${this.config.modelID} NOT FOUND`)
+			return
+		}
+
+		if (model.maxChannels === undefined) {
+			this.model = model
+		} else {
+			let channels = parseInt(this.config.channelCount)
+
+			if (isNaN(channels)) {
+				channels = model.channels
+			}
+
+			// copy so the shared model definition isn't modified
+			this.model = { ...model, channels: Math.min(Math.max(channels, 1), model.maxChannels) }
+		}
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class ShureWirelessInstance extends InstanceBase {
 			resetConnection = true
 		}
 
-		if (this.config.channelCount != config.channelCount) {
+		if (this.config.channelCount != config.channelCount || this.config.transmissionMode != config.transmissionMode) {
 			resetConnection = true
 		}
 
@@ -169,11 +169,21 @@ class ShureWirelessInstance extends InstanceBase {
 				default: 'ulxd4',
 			},
 			{
+				type: 'dropdown',
+				id: 'transmissionMode',
+				label: 'Transmission Mode',
+				tooltip: 'The wireless system the receiver is operating in.',
+				choices: Choices.TransmissionModes,
+				width: 3,
+				default: 'ad',
+				isVisible: (config) => config.modelID === 'anx4',
+			},
+			{
 				type: 'number',
 				id: 'channelCount',
 				label: 'Licensed Channels',
-				tooltip: 'The number of channels licensed on the receiver.',
-				width: 2,
+				tooltip: 'The number of channels licensed on the receiver.\nUp to 16 for Axient Digital, or 24 for ULX-D.',
+				width: 3,
 				min: 1,
 				max: 24,
 				default: 4,
@@ -482,17 +492,24 @@ class ShureWirelessInstance extends InstanceBase {
 			return
 		}
 
-		if (model.maxChannels === undefined) {
+		if (model.modes === undefined) {
 			this.model = model
-		} else {
-			let channels = parseInt(this.config.channelCount)
+			return
+		}
 
-			if (isNaN(channels)) {
-				channels = model.channels
-			}
+		let mode = model.modes[this.config.transmissionMode] ?? Object.values(model.modes)[0]
+		let channels = parseInt(this.config.channelCount)
 
-			// copy so the shared model definition isn't modified
-			this.model = { ...model, channels: Math.min(Math.max(channels, 1), model.maxChannels) }
+		if (isNaN(channels)) {
+			channels = model.channels
+		}
+
+		// copy so the shared model definition isn't modified
+		this.model = {
+			...model,
+			channels: Math.min(Math.max(channels, 1), mode.maxChannels),
+			slots: mode.slots,
+			ulxdChannels: mode.ulxdChannels === true,
 		}
 	}
 

--- a/src/internalAPI.js
+++ b/src/internalAPI.js
@@ -54,7 +54,7 @@ export default class WirelessApi {
 			//qlx-d rx [CHAN_NAME,METER_RATE,AUDIO_GAIN,GROUP_CHAN,FREQUENCY,ENCRYPTION_WARNING]
 			//ulx-d rx [CHAN_NAME,METER_RATE,AUDIO_GAIN,AUDIO_MUTE,GROUP_CHAN,FREQUENCY,ENCRYPTION_WARNING,RF_INT_DET]
 			//ad    rx [CHAN_NAME,METER_RATE,AUDIO_GAIN,AUDIO_MUTE,GROUP_CHANNEL,FREQUENCY,FLASH,ENCRYPTION_STATUS,INTERFERENCE_STATUS,UNREGISTERED_TX_STATUS]
-			//         [FD_MODE,GROUP_CHANNEL2,FREQUENCY2,INTERFERENCE_STATUS2]
+			//         [ANTENNA_CONFIGURATION,FD_MODE,GROUP_CHANNEL2,FREQUENCY2,INTERFERENCE_STATUS2]
 			//slx-d rx [CHAN_NAME,METER_RATE,AUDIO_GAIN,GROUP_CHAN,FREQUENCY,AUDIO_OUT_LVL_SWITCH]
 			//qlx-d tx [TX_TYPE,TX_DEVICE_ID,TX_OFFSET,TX_RF_PWR,TX_MUTE_STATUS,TX_PWR_LOCK,TX_MENU_LOCK,TX_MUTE_BUTTON_STATUS,TX_POWER_SOURCE]
 			//         [BATT_BARS,BATT_CHARGE,BATT_CYCLE,BATT_RUN_TIME,BATT_TEMP_F,BATT_TEMP_C,BATT_TYPE]
@@ -78,6 +78,7 @@ export default class WirelessApi {
 				encryptionStatus: 'OK', // (AD) OK - ERROR | (ULX+QLD:ENCRYPTION_WARNING) OFF=OK - ON=ERROR
 				interferenceStatus: 'NONE', // (AD) NONE - DETECTED | (ULX:RF_INT_DET) NONE - CRITICAL=DETECTED
 				unregisteredTxStatus: 'OK', // (AD) OK - ERROR
+				antennaConfiguration: 'AUTOMATIC', // (AD) AB - CD - AUTOMATIC - QUADVERSITY
 				fdMode: 'OFF', // (AD) OFF - FD-C - FD-S
 				groupChan2: '--,--', // xx,yy
 				group2: 0, // (AD) xx,yy (xx)
@@ -315,11 +316,12 @@ export default class WirelessApi {
 					channel.audioLevelPeak + (this.instance.config.variableFormat == 'units' ? ' dBFS' : ''),
 			})
 
-			if (this.receiver.quadversityMode == 'ON') {
+			// AD4D/AD4Q report quadversity for the receiver, ANX4 reports it per channel
+			if (this.receiver.quadversityMode == 'ON' || channel.antennaConfiguration == 'QUADVERSITY') {
 				channel.rfLevelC = parseInt(sample[13]) - 120
 				channel.rfBitmapC = parseInt(sample[12])
-				channel.rfLevelC = parseInt(sample[15]) - 120
-				channel.rfBitmapC = parseInt(sample[14])
+				channel.rfLevelD = parseInt(sample[15]) - 120
+				channel.rfBitmapD = parseInt(sample[14])
 				channel.antennaC = sample[7].substr(2, 1)
 				channel.antennaD = sample[7].substr(3, 1)
 				this.instance.setVariableValues({
@@ -567,6 +569,9 @@ export default class WirelessApi {
 		} else if (key == 'UNREGISTERED_TX_STATUS') {
 			channel.unregisteredTxStatus = value
 			this.instance.setVariableValues({ [`${prefix}unregistered_tx_status`]: value })
+		} else if (key == 'ANTENNA_CONFIGURATION') {
+			channel.antennaConfiguration = value
+			this.instance.setVariableValues({ [`${prefix}antenna_configuration`]: value })
 		} else if (key == 'FD_MODE') {
 			channel.fdMode = value
 			this.instance.setVariableValues({ [`${prefix}fd_mode`]: value })

--- a/src/internalAPI.js
+++ b/src/internalAPI.js
@@ -306,9 +306,13 @@ export default class WirelessApi {
 			channel.antennaA = sample[7].substr(0, 1)
 			channel.antennaB = sample[7].substr(1, 1)
 
+			// channel quality is only reported for Axient Digital channels
+			if (!this.instance.model.ulxdChannels) {
+				this.instance.setVariableValues({ [`${prefix}signal_quality`]: channel.signalQuality })
+			}
+
 			this.instance.setVariableValues({
 				[`${prefix}antenna`]: channel.antenna,
-				[`${prefix}signal_quality`]: channel.signalQuality,
 				[`${prefix}rf_level_a`]: channel.rfLevelA + (this.instance.config.variableFormat == 'units' ? ' dBm' : ''),
 				[`${prefix}rf_level_b`]: channel.rfLevelB + (this.instance.config.variableFormat == 'units' ? ' dBm' : ''),
 				[`${prefix}audio_level`]: channel.audioLevel + (this.instance.config.variableFormat == 'units' ? ' dBFS' : ''),

--- a/src/setup.js
+++ b/src/setup.js
@@ -16,6 +16,15 @@ function CreateModelChoices() {
 	return choices
 }
 
+// Receivers that support more than one wireless system, such as the ANX4, change their
+// feature set with the selected transmission mode.  Transmitter slots and the channel
+// maximum are per the ANX4 user guide; standard vs high density is reported by the
+// receiver itself via TRANSMISSION_MODE.
+export const TransmissionModes = {
+	ad: { id: 'ad', label: 'Axient Digital', maxChannels: 16, slots: 8 },
+	ulxd: { id: 'ulxd', label: 'ULX-D', maxChannels: 24, slots: 0, ulxdChannels: true },
+}
+
 export const Models = {
 	ulxd4: { id: 'ulxd4', family: 'ulx', label: 'ULXD4 Single Receiver', channels: 1, slots: 0 },
 	ulxd4d: { id: 'ulxd4d', family: 'ulx', label: 'ULXD4D Dual Receiver', channels: 2, slots: 0 },
@@ -23,13 +32,14 @@ export const Models = {
 	qlxd4: { id: 'qlxd4', family: 'qlx', label: 'QLXD4 Single Receiver', channels: 1, slots: 0 },
 	ad4d: { id: 'ad4d', family: 'ad', label: 'AD4D Dual Receiver', channels: 2, slots: 8 },
 	ad4q: { id: 'ad4q', family: 'ad', label: 'AD4Q Quad Receiver', channels: 4, slots: 8 },
-	anx4: { id: 'anx4', family: 'ad', label: 'ANX4 Scalable Receiver', channels: 4, maxChannels: 24, slots: 8 },
+	anx4: { id: 'anx4', family: 'ad', label: 'ANX4 Scalable Receiver', channels: 4, slots: 8, modes: TransmissionModes },
 	slxd4: { id: 'slxd4', family: 'slx', label: 'SLXD4 Single Receiver', channels: 1, slots: 0 },
 	slxd4d: { id: 'slxd4d', family: 'slx', label: 'SLXD4D Dual Receiver', channels: 2, slots: 0 },
 }
 
 export const Choices = {
 	Models: CreateModelChoices(),
+	TransmissionModes: Object.values(TransmissionModes).map(({ id, label }) => ({ id, label })),
 	OnOffToggle: [
 		{ id: 'ON', label: 'Mute' },
 		{ id: 'OFF', label: 'Unmute' },

--- a/src/setup.js
+++ b/src/setup.js
@@ -23,6 +23,7 @@ export const Models = {
 	qlxd4: { id: 'qlxd4', family: 'qlx', label: 'QLXD4 Single Receiver', channels: 1, slots: 0 },
 	ad4d: { id: 'ad4d', family: 'ad', label: 'AD4D Dual Receiver', channels: 2, slots: 8 },
 	ad4q: { id: 'ad4q', family: 'ad', label: 'AD4Q Quad Receiver', channels: 4, slots: 8 },
+	anx4: { id: 'anx4', family: 'ad', label: 'ANX4 Scalable Receiver', channels: 4, maxChannels: 24, slots: 8 },
 	slxd4: { id: 'slxd4', family: 'slx', label: 'SLXD4 Single Receiver', channels: 1, slots: 0 },
 	slxd4d: { id: 'slxd4d', family: 'slx', label: 'SLXD4D Dual Receiver', channels: 2, slots: 0 },
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -34,7 +34,11 @@ export function updateVariables() {
 		}
 
 		if (this.model.family == 'ad') {
-			variables.push({ variableId: `${prefix}_unregistered_tx_status`, name: `Channel ${i} Unregistered TX Status` })
+			// unregistered transmitters only apply to Axient Digital channels
+			if (!this.model.ulxdChannels) {
+				variables.push({ variableId: `${prefix}_unregistered_tx_status`, name: `Channel ${i} Unregistered TX Status` })
+			}
+
 			variables.push({ variableId: `${prefix}_fd_mode`, name: `Channel ${i} FD Mode` })
 			variables.push({ variableId: `${prefix}_group_chan2`, name: `Channel ${i} Group & Channel 2` })
 			variables.push({ variableId: `${prefix}_frequency2`, name: `Channel ${i} Frequency 2` })
@@ -47,7 +51,12 @@ export function updateVariables() {
 
 		if (this.model.family == 'ad') {
 			variables.push({ variableId: `${prefix}_antenna_configuration`, name: `Channel ${i} Antenna Configuration` })
-			variables.push({ variableId: `${prefix}_signal_quality`, name: `Channel ${i} Signal Quality` })
+
+			// channel quality is only reported for Axient Digital channels
+			if (!this.model.ulxdChannels) {
+				variables.push({ variableId: `${prefix}_signal_quality`, name: `Channel ${i} Signal Quality` })
+			}
+
 			variables.push({ variableId: `${prefix}_rf_level_a`, name: `Channel ${i} RF Level A` })
 			variables.push({ variableId: `${prefix}_rf_level_b`, name: `Channel ${i} RF Level B` })
 			variables.push({ variableId: `${prefix}_rf_level_c`, name: `Channel ${i} RF Level C` })

--- a/src/variables.js
+++ b/src/variables.js
@@ -46,6 +46,7 @@ export function updateVariables() {
 		}
 
 		if (this.model.family == 'ad') {
+			variables.push({ variableId: `${prefix}_antenna_configuration`, name: `Channel ${i} Antenna Configuration` })
 			variables.push({ variableId: `${prefix}_signal_quality`, name: `Channel ${i} Signal Quality` })
 			variables.push({ variableId: `${prefix}_rf_level_a`, name: `Channel ${i} RF Level A` })
 			variables.push({ variableId: `${prefix}_rf_level_b`, name: `Channel ${i} RF Level B` })


### PR DESCRIPTION
Closes #56.

The ANX4 shares the Axient Digital command set, so it is added to the existing `ad` family rather than introducing a new one. I diffed the [ANX4 command strings](https://www.shure.com/en-US/docs/commandstrings/ANX4) against the module: every command it implements appears in the ANX4 spec, on the same port 2202, with the same `SAMPLE` layout and the same 8 transmitter slots per channel. Since the actions, feedbacks, variables and icons all branch on `model.family`, `family: 'ad'` picks up the existing feature set unchanged.

### Licensed channel count

The one thing that does not fit the existing model table is the channel count. Unlike the AD4D/AD4Q, the ANX4's is determined by the licenses installed on the receiver (1-24, or up to 16 in ULX-D transmission mode). Declaring a flat 24 would generate roughly 4,000 variables and a 217-entry slot dropdown for a receiver that might only be licensed for four channels.

Instead, a model may now declare a `maxChannels`, which marks its channel count as licensable and exposes a "Licensed Channels" config field (shown only when such a model is selected). `setupModel()` copies the model definition before overriding `channels`, so the shared `Models` export is not mutated between instances. Models without `maxChannels` are returned as-is and behave exactly as before.

I went with a config field rather than reading `AVAILABLE_CHANNELS`/`NUMBER_CHANNELS_LICENSED` off the device to keep this consistent with the module's existing static-model design — happy to switch to auto-detection if you'd prefer that.

### Two AD fixes the ANX4 exposes

These affect the AD4D/AD4Q today, not just the ANX4:

- `parseADSample` assigned `rfLevelC`/`rfBitmapC` twice instead of the D values, so **RF level D was never populated on any quadversity channel**.
- Quadversity is a receiver-level `QUADVERSITY_MODE` property on the AD4D/AD4Q, but a per-channel `ANTENNA_CONFIGURATION` property on the ANX4. It is now tracked per channel (with a new `ch_N_antenna_configuration` variable for the `ad` family) and used alongside the receiver property to select the quadversity sample layout, so both receiver types work.

### Testing

Verified against a real ANX4 on Companion 5.0.0: the model appears, the "Licensed Channels" field shows and hides correctly, and channels, slots and variables scale to the configured count.

The parsing changes were additionally checked with a harness that stubs the instance and asserts against the quadversity `SAMPLE` string from Shure's documentation, confirming RF level D now reads correctly where it was previously unset, and that AD4Q receiver-level quadversity and ULX-D behaviour are unaffected. `prettier --check` passes.

I bumped the version to 2.4.0, but happy to drop that commit if you'd rather handle versioning yourself.
