### PR TITLE
fix: render channel status icons in Companion v5

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -104,9 +104,13 @@ export function updateFeedbacks() {
 		callback: (event) => {
 			let opt = event.options
 			let channel = this.api.getChannel(parseInt(opt.channel))
+			let icon = this.api.getIcon(opt, event.image)
 			let out = {
 				alignment: 'left:top',
-				imageBuffers: [{ buffer: this.api.getIcon(opt, event.image) }],
+				imageBuffer: icon,
+				imageBufferEncoding: { pixelFormat: 'ARGB' },
+				// Kept for Companion v4 installations that still consume the legacy field.
+				imageBuffers: [{ buffer: icon }],
 				size: '7',
 				text: '',
 			}


### PR DESCRIPTION
## Summary
- return the Companion v5 `imageBuffer` field for Channel Status Display
- declare the generated buffer as ARGB
- retain the legacy `imageBuffers` field for older Companion installations

## Validation
- verified the feedback result contains the current image buffer, ARGB encoding, and the legacy field
- `prettier --check src/feedback.js`

Fixes #74