### PR TITLE
feat: expose battery runtime minutes as variables

### DIFF
--- a/src/internalAPI.js
+++ b/src/internalAPI.js
@@ -778,7 +778,10 @@ export default class WirelessApi {
 				variable = `${h}:${m}`
 			}
 			channel.batteryRuntime2 = variable
-			this.instance.setVariableValues({ [`${prefix}battery_runtime`]: variable })
+			this.instance.setVariableValues({
+				[`${prefix}battery_runtime`]: variable,
+				[`${prefix}battery_runtime_mins`]: channel.batteryRuntime,
+			})
 		} else if (key.match(/BATT_TEMP_C/)) {
 			channel.batteryTempC = parseInt(value)
 			if (channel.batteryTempC == 255) {
@@ -1008,7 +1011,10 @@ export default class WirelessApi {
 					m = m < 10 ? '0' + m : m
 					variable = `${h}:${m}`
 				}
-				this.instance.setVariableValues({ [`${prefix}battery_runtime`]: variable })
+				this.instance.setVariableValues({
+					[`${prefix}battery_runtime`]: variable,
+					[`${prefix}battery_runtime_mins`]: slot.batteryRuntime,
+				})
 				break
 			case 'SLOT_BATT_TYPE':
 				slot.batteryType = value

--- a/src/variables.js
+++ b/src/variables.js
@@ -109,6 +109,7 @@ export function updateVariables() {
 		}
 
 		variables.push({ variableId: `${prefix}_battery_runtime`, name: `Channel ${i} Battery Run Time` })
+		variables.push({ variableId: `${prefix}_battery_runtime_mins`, name: `Channel ${i} Battery Run Time (Minutes)` })
 
 		if (this.model.family != 'slx') {
 			variables.push({ variableId: `${prefix}_battery_temp_f`, name: `Channel ${i} Battery Temperature (F)` })
@@ -136,6 +137,7 @@ export function updateVariables() {
 				variables.push({ variableId: `${prefix}_battery_cycle`, name: `Slot ${id} Battery Cycle` })
 				variables.push({ variableId: `${prefix}_battery_health`, name: `Slot ${id} Battery Health` })
 				variables.push({ variableId: `${prefix}_battery_runtime`, name: `Slot ${id} Battery Run Time` })
+				variables.push({ variableId: `${prefix}_battery_runtime_mins`, name: `Slot ${id} Battery Run Time (Minutes)` })
 				variables.push({ variableId: `${prefix}_battery_type`, name: `Slot ${id} Battery Type` })
 			}
 		}


### PR DESCRIPTION
Fixes #30.

Adds numeric battery-runtime variables for channels and AD slots. The existing `battery_runtime` values remain formatted for display (for example `7:30`); the new `battery_runtime_mins` values retain the raw minute count that the receiver reports, so Companion triggers and comparisons can use a number directly.

Validation:
- mocked `TX_BATT_MINS 450` produces display `7:30` and raw value `450`
- mocked `SLOT_BATT_MINS 15` produces display `0:15` and raw value `15`
- `prettier --check src/internalAPI.js src/variables.js`

This legacy module does not define an automated test script.