### PR TITLE
feat: add transmitter talk switch feedback

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -25,20 +25,21 @@ This module will connect to the Shure receivers below to provide feedback status
 
 ### Available feedbacks
 
-| Title                  | Description                                                                                   | Model Support       |
-| ---------------------- | --------------------------------------------------------------------------------------------- | ------------------- |
-| Battery Level          | If the battery bar drops to or below a certain value, change the color of the button.         | All                 |
-| Channel Frequency      | If the selected channel\'s frequency is set, change the color of the button.                  | ULX, QLX, SLX, & AD |
-| Channel Gain           | If the selected channel\'s gain is set, change the color of the button.                       | All                 |
-| Channel Muted          | If the selected channel is muted, change the color of the button.                             | ULX, AD             |
-| Channel Status Display | **See below**                                                                                 | ULX, QLX, SLX, & AD |
-| Interference Status    | If the selected channel gets interference, change the color of the button.                    | ULX, QLX, AD        |
-| Transmitter Muted      | If the selected channel\'s transmitter is muted, change the color of the button.              | ULX, QLX, & AD      |
-| Transmitter Turned Off | If the selected channel\'s transmitter is powered off, change the color of the button.        | All                 |
-| Slot is Active         | If the selected slot\'s transmitter is active to the channel, change the color of the button. | AD                  |
-| Slot RF Output         | If the selected slot\'s transmitter RF is set, change the color of the button.                | ADX only            |
-| Slot RF Power          | If the selected slot\'s transmitter power level is set, change the color of the button.       | ADX only            |
-| Slot Status            | If the selected slot\'s status is set, change the color of the button.                        | AD                  |
+| Title                   | Description                                                                                         | Model Support       |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
+| Battery Level           | If the battery bar drops to or below a certain value, change the color of the button.               | All                 |
+| Channel Frequency       | If the selected channel\'s frequency is set, change the color of the button.                        | ULX, QLX, SLX, & AD |
+| Channel Gain            | If the selected channel\'s gain is set, change the color of the button.                             | All                 |
+| Channel Muted           | If the selected channel is muted, change the color of the button.                                   | ULX, AD             |
+| Channel Status Display  | **See below**                                                                                       | ULX, QLX, SLX, & AD |
+| Interference Status     | If the selected channel gets interference, change the color of the button.                          | ULX, QLX, AD        |
+| Transmitter Muted       | If the selected channel\'s transmitter is muted, change the color of the button.                    | ULX, QLX, & AD      |
+| Transmitter Talk Switch | If the selected channel\'s transmitter talk/mute button is pressed, change the color of the button. | ULX, QLX, & AD      |
+| Transmitter Turned Off  | If the selected channel\'s transmitter is powered off, change the color of the button.              | All                 |
+| Slot is Active          | If the selected slot\'s transmitter is active to the channel, change the color of the button.       | AD                  |
+| Slot RF Output          | If the selected slot\'s transmitter RF is set, change the color of the button.                      | ADX only            |
+| Slot RF Power           | If the selected slot\'s transmitter power level is set, change the color of the button.             | ADX only            |
+| Slot Status             | If the selected slot\'s status is set, change the color of the button.                              | AD                  |
 
 ### Channel Status Display
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "node --test",
 		"format": "prettier --write ."
 	},
 	"repository": {

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -210,6 +210,20 @@ export function updateFeedbacks() {
 			},
 		}
 
+		feedbacks['transmitter_talk_switch'] = {
+			type: 'boolean',
+			name: 'Transmitter Talk Switch',
+			description: "If the selected channel's transmitter talk/mute button is pressed, change the color of the button.",
+			defaultStyle: {
+				color: combineRgb(255, 255, 255),
+				bgcolor: combineRgb(0, 128, 0),
+			},
+			options: [this.CHANNELS_FIELD],
+			callback: ({ options }) => {
+				return this.api.getChannel(parseInt(options.channel)).txTalkSwitch == 'PRESSED'
+			},
+		}
+
 		feedbacks['interference_status'] = {
 			type: 'boolean',
 			name: 'Interference Status',

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -210,18 +210,21 @@ export function updateFeedbacks() {
 			},
 		}
 
-		feedbacks['transmitter_talk_switch'] = {
-			type: 'boolean',
-			name: 'Transmitter Talk Switch',
-			description: "If the selected channel's transmitter talk/mute button is pressed, change the color of the button.",
-			defaultStyle: {
-				color: combineRgb(255, 255, 255),
-				bgcolor: combineRgb(0, 128, 0),
-			},
-			options: [this.CHANNELS_FIELD],
-			callback: ({ options }) => {
-				return this.api.getChannel(parseInt(options.channel)).txTalkSwitch == 'PRESSED'
-			},
+		if (this.model.family == 'ad') {
+			feedbacks['transmitter_talk_switch'] = {
+				type: 'boolean',
+				name: 'Transmitter Talk Switch',
+				description:
+					"If the selected channel's transmitter talk/mute button is pressed, change the color of the button.",
+				defaultStyle: {
+					color: combineRgb(255, 255, 255),
+					bgcolor: combineRgb(0, 128, 0),
+				},
+				options: [this.CHANNELS_FIELD],
+				callback: ({ options }) => {
+					return this.api.getChannel(parseInt(options.channel)).txTalkSwitch == 'PRESSED'
+				},
+			}
 		}
 
 		feedbacks['interference_status'] = {

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -210,7 +210,7 @@ export function updateFeedbacks() {
 			},
 		}
 
-		if (this.model.family == 'ad') {
+		if (['ad', 'qlx', 'ulx'].includes(this.model.family)) {
 			feedbacks['transmitter_talk_switch'] = {
 				type: 'boolean',
 				name: 'Transmitter Talk Switch',

--- a/src/internalAPI.js
+++ b/src/internalAPI.js
@@ -674,6 +674,7 @@ export default class WirelessApi {
 			}
 			channel.txTalkSwitch = variable
 			this.instance.setVariableValues({ [`${prefix}tx_talk_switch`]: variable })
+			this.instance.checkFeedbacks('transmitter_talk_switch')
 		} else if (key == 'TX_OFFSET') {
 			channel.txOffset = parseInt(value)
 			if (channel.txOffset == 255) {

--- a/test/feedback.test.js
+++ b/test/feedback.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { updateFeedbacks } from '../src/feedback.js'
+
+function feedbacksFor(family, txTalkSwitch) {
+	const instance = {
+		model: { family },
+		CHANNELS_FIELD: { type: 'dropdown', id: 'channel' },
+		SLOTS_FIELD: { type: 'dropdown', id: 'slot' },
+		api: {
+			getChannel: () => ({ txTalkSwitch }),
+		},
+		setFeedbackDefinitions: (feedbacks) => {
+			instance.feedbacks = feedbacks
+		},
+	}
+
+	updateFeedbacks.call(instance)
+	return instance.feedbacks
+}
+
+for (const family of ['ad', 'qlx', 'ulx']) {
+	test(`${family} exposes transmitter talk switch feedback`, () => {
+		const feedback = feedbacksFor(family, 'PRESSED').transmitter_talk_switch
+
+		assert.ok(feedback)
+		assert.equal(feedback.callback({ options: { channel: '1' } }), true)
+	})
+}
+
+test('slx does not expose transmitter talk switch feedback', () => {
+	assert.equal(feedbacksFor('slx', 'PRESSED').transmitter_talk_switch, undefined)
+})


### PR DESCRIPTION
## Summary
- add a boolean feedback for the transmitter talk/mute button state
- refresh that feedback when `TX_TALK_SWITCH` changes
- reuse the status parsing already present in the module

Closes #69

## Validation
- Prettier check
- mocked AD-family `TX_TALK_SWITCH` ON/OFF responses, verifying parsing, feedback refresh, and pressed/released button state

## Hardware confirmation requested
Please verify on an ADX AD651B whether the status remains active for the intended talkback state, rather than only the physical press duration.