### PR TITLE
fix: restore channel status icons in Companion 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "node --test test/*.test.js",
 		"format": "prettier --write ."
 	},
 	"repository": {

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -106,7 +106,7 @@ export function updateFeedbacks() {
 			let channel = this.api.getChannel(parseInt(opt.channel))
 			let out = {
 				alignment: 'left:top',
-				imageBuffers: [{ buffer: this.api.getIcon(opt, event.image) }],
+				imageBuffer: this.api.getIcon(opt, event.image),
 				size: '7',
 				text: '',
 			}

--- a/src/icons.js
+++ b/src/icons.js
@@ -613,18 +613,19 @@ export default class Icons {
 		let out
 
 		if (image && image.width && image.height) {
+			// A zero reading still draws an icon; only undefined means it is hidden.
 			let id =
 				image.width +
 				'x' +
 				image.height +
 				(ant ? 'a' + ant : '') +
-				(audio ? 'b' + audio : '') +
-				(rfA ? 'c' + rfA : '') +
-				(rfB ? 'd' + rfB : '') +
-				(battery ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '') +
+				(audio !== undefined ? 'b' + audio : '') +
+				(rfA !== undefined ? 'c' + rfA : '') +
+				(rfB !== undefined ? 'd' + rfB : '') +
+				(battery !== undefined ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '') +
 				(lock ? 'f' + lock : '') +
 				(encryption ? 'g' + encryption : '') +
-				(quality ? 'h' + quality : '')
+				(quality !== undefined ? 'h' + quality : '')
 
 			if (this.savedIcons[id] === undefined) {
 				let img = new Image(image.width, image.height)
@@ -691,9 +692,9 @@ export default class Icons {
 				image.width +
 				'x' +
 				image.height +
-				(audio ? 'b' + audio : '') +
-				(rf ? 'c' + rf : '') +
-				(battery ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '')
+				(audio !== undefined ? 'b' + audio : '') +
+				(rf !== undefined ? 'c' + rf : '') +
+				(battery !== undefined ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '')
 
 			if (this.savedIcons[id] === undefined) {
 				let img = new Image(image.width, image.height)
@@ -746,9 +747,9 @@ export default class Icons {
 				'x' +
 				image.height +
 				(ant ? 'a' + ant : '') +
-				(audio ? 'b' + audio : '') +
-				(rf ? 'c' + rf : '') +
-				(battery ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '') +
+				(audio !== undefined ? 'b' + audio : '') +
+				(rf !== undefined ? 'c' + rf : '') +
+				(battery !== undefined ? 'e' + (battery <= batteryAlertLevel ? battery + 'R' : battery) : '') +
 				(lock ? 'f' + lock : '') +
 				(encryption ? 'g' + encryption : '')
 

--- a/test/icons.test.js
+++ b/test/icons.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { updateFeedbacks } from '../src/feedback.js'
+import Icons from '../src/icons.js'
+
+const families = [
+	{
+		name: 'Axient',
+		method: 'getADStatus',
+		args: ['BB', 2, 2, 2, 4, 2, 'ALL', 'ON', 3],
+		fields: { audio: 1, rfA: 2, rfB: 3, battery: 4, quality: 8 },
+	},
+	{
+		name: 'QLX-D / ULX-D',
+		method: 'getULXStatus',
+		args: ['AX', 2, 2, 4, 2, 'ALL', 'ON'],
+		fields: { audio: 1, rf: 2, battery: 3 },
+	},
+	{
+		name: 'SLX-D',
+		method: 'getSLXStatus',
+		args: [2, 2, 4, 2],
+		fields: { audio: 0, rf: 1, battery: 2 },
+	},
+]
+
+for (const family of families) {
+	for (const height of [58, 72]) {
+		const image = { width: 72, height }
+		for (const [field, index] of Object.entries(family.fields)) {
+			for (const [before, after] of [
+				[undefined, 0],
+				[0, undefined],
+			]) {
+				test(`${family.name} ${height}px ${field}: ${before} -> ${after} matches a fresh render`, () => {
+					const initial = [...family.args]
+					initial[index] = before
+					const next = [...family.args]
+					next[index] = after
+					const cached = new Icons({})
+					const firstImage = cached[family.method](image, ...initial)
+					const expected = new Icons({})[family.method](image, ...next)
+
+					// The real pixel output differs: zero is a visible state, not an omitted icon.
+					assert.ok(firstImage !== expected, 'Zero and hidden must produce different pixels')
+					assert.ok(cached[family.method](image, ...next) === expected, 'Cached pixels must match a fresh render')
+					assert.ok(
+						cached[family.method](image, ...initial) === firstImage,
+						'Returning to the initial state must match'
+					)
+				})
+			}
+		}
+	}
+
+	test(`${family.name}: identical zero-valued states still reuse the cache`, () => {
+		const icons = new Icons({})
+		const args = [...family.args]
+		for (const index of Object.values(family.fields)) args[index] = 0
+		const image = { width: 72, height: 72 }
+		const first = icons[family.method](image, ...args)
+		assert.equal(Object.keys(icons.savedIcons).length, 1)
+		icons.drawFromPNGdata = () => {
+			throw new Error('Unchanged state should use the cached image')
+		}
+		assert.equal(icons[family.method](image, ...args), first)
+	})
+}
+
+test('channel status returns the current Companion imageBuffer property', () => {
+	let definitions
+	const context = {
+		model: { family: 'ad' },
+		CHANNELS_FIELD: {},
+		SLOTS_FIELD: {},
+		api: {
+			getChannel: () => ({
+				name: 'AD4Q',
+				frequency: 600000,
+				txType: 'ADX2',
+				txPowerLevel: 10,
+			}),
+			getIcon: () => 'base64-png',
+		},
+		setFeedbackDefinitions: (value) => {
+			definitions = value
+		},
+	}
+
+	updateFeedbacks.call(context)
+	const result = definitions.sample.callback({
+		image: { width: 72, height: 72 },
+		options: { channel: '1', labels: [], icons: [], barlevel: 1 },
+	})
+
+	assert.equal(result.imageBuffer, 'base64-png')
+	assert.equal('imageBuffers' in result, false)
+})


### PR DESCRIPTION
## Summary

The advanced `Channel Status Display` still returns its image through the retired plural `imageBuffers` shape. Companion 5 expects the current singular `imageBuffer` property, so the text remains visible while the generated status icons are discarded.

This changes the feedback result to `imageBuffer` and adds a regression test for that API shape.

While testing the render path, I also found a separate cache collision: a real meter value of `0` produced the same cache key as a hidden/undefined icon. That could leave stale pixels after a meter transitions between hidden and zero. Cache keys now distinguish those states for Axient, QLX-D/ULX-D, and SLX-D.

Closes #74.

## Verification

- 48 Node tests pass, covering both 58px and 72px layouts across Axient, QLX-D/ULX-D and SLX-D
- targeted Prettier check passes
- `companion-module-build` succeeds

No receiver command or protocol behaviour changes. Hardware validation is still requested on AD4D/AD4Q with Companion 5.
